### PR TITLE
changed @import to #import and used cocoapods to import the frameworks-- fixed

### DIFF
--- a/Diskcached.podspec
+++ b/Diskcached.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
                     }
   s.source_files = 'Diskcached/*.{h,m}'
   s.requires_arc = true
-  s.frameworks    = 'UIKit’, ‘Foundation’
+  s.frameworks    = 'UIKit', 'Foundation'
 
 end

--- a/Diskcached.podspec
+++ b/Diskcached.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
                     }
   s.source_files = 'Diskcached/*.{h,m}'
   s.requires_arc = true
-  s.framework    = 'UIKit'
+  s.frameworks    = 'UIKit’, ‘Foundation’
 
 end

--- a/Diskcached/Diskcached.h
+++ b/Diskcached/Diskcached.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2014年 Hirohisa Kawasaki. All rights reserved.
 //
 
-@import Foundation;
-@import UIKit;
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface NSString (Encode)
 


### PR DESCRIPTION
Cocoa pods can manage OS frameworks imports, so no need to use @import

On the other hand projects that doesn't support Modules will not be able to integrate Diskcached.
